### PR TITLE
✨feat: textarea 공통 컴포넌트에 글자수 유효성 검사 기능 추가

### DIFF
--- a/src/components/common/Textarea.jsx
+++ b/src/components/common/Textarea.jsx
@@ -1,19 +1,71 @@
+import { useState } from 'react';
+
 const Textarea = ({
   placeholder = '',
   value,
   onChange,
-  maxLength = 300, //기본 300자 제한
   height = 150, // 기본 150px
   textsize = 'text-sm',
-}) => (
-  <textarea
-    placeholder={placeholder}
-    value={value}
-    onChange={onChange}
-    maxLength={maxLength}
-    required
-    className={`w-full h-[${height}px] whitespace-pre-wrap px-3 py-3 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-blue-500 resize-none ${textsize}`}
-  />
-);
+  maxLength = 300, // 기본 300 글자
+}) => {
+  // 1. 글자수 초과 시, 에러 메시지 상태관리
+  const [error, setError] = useState('');
+  const [inputCount, setInputCount] = useState(0);
+
+  // 2. 마우스 포커스를 잃을 시, 자동으로 오류 메시지 제거
+  const handleBlur = () => {
+    setError('');
+  };
+
+  // 3. 한글, 영문, 숫자 등을 1자로 카운트
+  const getTextLengthAllType = (text) => {
+    return Array.from(text).length;
+  };
+
+  // 4. onChange로 받아오는 값에서 getTextLenghAllType으로 텍스트 검증
+  const handleTextChange = (e) => {
+    let text = e.target.value;
+    const realTextLength = getTextLengthAllType(text);
+
+    if (realTextLength > maxLength) {
+      setError(`작성하신 글이 제한 글자수를 초과했습니다`);
+    } else {
+      setError('');
+    }
+
+    // 글자 수 초과 시, 초과된 부분을 잘라내고 반환
+    if (realTextLength > maxLength) {
+      text = text.slice(0, maxLength);
+    }
+    setInputCount(getTextLengthAllType(text));
+
+    // 브라우저 상태 반영
+    onChange({ ...e, target: { ...e.target, value: text } });
+  };
+
+  return (
+    <div>
+      <textarea
+        placeholder={placeholder}
+        value={value}
+        onChange={handleTextChange}
+        onBlur={handleBlur}
+        required
+        className={`w-full h-[${height}px] whitespace-pre-wrap px-3 py-3 border border-gray-300 rounded-lg outline-none focus:ring-2 focus:ring-blue-500 resize-none ${textsize}`}
+      />
+      <div className="flex justify-end text-gray-500">
+        {inputCount}/{maxLength} 자
+      </div>
+      <div
+        className={`text-red-500 transition-opacity duration-500 ease-in-out mb-8 ${
+          error ? 'opacity-100' : 'opacity-0'
+        }`}
+      >
+        {error || <div>&nbsp;</div>}
+        {/* Non-breaking space로 에러메세지가 없어도 해당 공간 만큼 차지하고 있도록 설정 _ 아래 내용이 밑으로 밀리는 현상 방지 */}
+      </div>
+    </div>
+  );
+};
 
 export default Textarea;

--- a/src/pages/ReviewEditor.jsx
+++ b/src/pages/ReviewEditor.jsx
@@ -81,17 +81,17 @@ const ReviewEditor = () => {
       <h3>리뷰 작성 페이지</h3>
       <form onSubmit={handleAddSubmit}>
         <h4>Content</h4>
-        <p>
+        <div>
           <Textarea
             placeholder="리뷰는 300자 이하로 작성해주세요."
             value={content}
             onChange={(e) => setContent(e.target.value)}
           />
-        </p>
+        </div>
         {/* 현재 이미지 1개 우선 구현 */}
-        <p>
+        <div>
           <input type="file" name="upload" accept="image/*" onChange={handleImageFileChange} />
-        </p>
+        </div>
         {/* 추후 이미지 2개 이상 구현 예정*/}
         {/* <p>
           <input type="file" multiple="multiple" name="upload" accept="image/*" onChange={handleImageFileChange} />


### PR DESCRIPTION
## 📌 변경 사항

1. 글자수 유효성 검사 추가 (용준님 의견 반영해서 작업해봤습니다!)
* 지정 글자수 초과 시, 빨간색 글씨로 초과되었다고 알려주는 검사입니다!

## 🛠️ 변경 이유 및 설명

- 사용자의 편의성을 위해 300/300자 (해당 maxLength값에 따라 숫자 자동 반영되도록 설정) 부분 추가
- alert창 대신 입력란 바로 아래에 빨간 글씨로 알려줌
- 마우스 포커스가 해당 텍스트에리어를 벗어날 시에 오류메세지 자동 삭제 (이거는 이미 300자 이상 글자를 입력하지 못하게 해놨기 때문에 오류메세지가 계속 남아있지 않도록 하기 위해 추가)

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 테스트를 거쳤습니다.

## 📸 스크린샷 (선택)

-한글,영어,숫자등 1글자로 계산하도록 반영
![chrome-capture-2025-3-2 (2)](https://github.com/user-attachments/assets/0ebb6dd2-72e6-4caa-859c-e519a9c48f66)

-300자 초과 시 사용자에게 알려주는 빨간 글씨 추가
![chrome-capture-2025-3-2 (3)](https://github.com/user-attachments/assets/b8a583c3-89db-4465-84a2-b65f629a692a)


